### PR TITLE
Add Nvidia controller rules, fix Steam Controller rule

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -2,7 +2,7 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
 
 # Steam Controller udev write access
-KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", TAG+="uaccess"
+KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
 
 # Valve HID devices over USB hidraw
 KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"

--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -63,3 +63,12 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="0c12", ATTRS{idProduct}=="0e10", MODE="0660
 
 # STRIKEPAD PS4 Grip Add-on
 KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c5", MODE="0660", TAG+="uaccess"
+
+# NVIDIA Shield Portable (2013 - NVIDIA_Controller_v01.01 - In-Home Streaming only)
+KERNEL=="hidraw*", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7203", MODE="0660", TAG+="uaccess", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_MOUSE}=""
+
+# NVIDIA Shield Controller (2015 - NVIDIA_Controller_v01.03 over USB hidraw)
+KERNEL=="hidraw*", ATTRS{idVendor}=="0955", ATTRS{idProduct}=="7210", MODE="0660", TAG+="uaccess", ENV{ID_INPUT_JOYSTICK}="1", ENV{ID_INPUT_MOUSE}=""
+
+# NVIDIA Shield Controller (2017 - NVIDIA_Controller_v01.04 over bluetooth hidraw)
+KERNEL=="hidraw*", KERNELS=="*0955:7214*", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Add Nvidia Shield controller support:
- Nvidia Shield Controller 2015 (USB)
- Nvidia Shield Controller 2017 (Bluetooth & USB)
- Nvidia Shield Portable 2013 (In-Home Streaming only)

This is for both permission setting and to make sure the controllers are not detected as a Mouse in Steam Big Picture mode but as a Gamepad.

Also fix a double declaration for a tag in the Steam Controller rule and fix for user level input.

@TTimo @kparal this is the PR announced precedently.