### PR TITLE
Prototype workaround for PowerA Wireless Controller

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -34,6 +34,13 @@ KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0660", TAG+="uaccess"
 # PowerA Wired Controller for Nintendo Switch
 KERNEL=="hidraw*", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a711", MODE="0660", TAG+="uaccess"
 
+# PowerA Wireless Controller for Nintendo Switch we have to use
+# ATTRS{name} since VID/PID are reported as zeros. We use /bin/sh
+# instead of udevadm directly becuase we need to use '*' glob at the
+# end of "hidraw" name since we don't know the index it'd have.
+#
+KERNEL=="input*", ATTRS{name}=="Lic Pro Controller", RUN{program}+="/bin/sh -c \"udevadm test-builtin uaccess /sys/%p/../../hidraw/hidraw*\""
+
 # Nacon PS4 Revolution Pro Controller
 KERNEL=="hidraw*", ATTRS{idVendor}=="146b", ATTRS{idProduct}=="0d01", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Prototype a workaround for PowerA Wireless Controller, which doesn't
report valid VID/PID via Bluetooth making it hard to properly tag it
with "uaccess" via UDEV.

The approach taken by this commit is to trigger on input device,
instead of the usual hidraw, and then rely on "udevadm test-builtin"
to apply "uacess" permission at runtime.

The reason to trigger on input device is because it is the first
device in device hierarchy that gets access to reported "name" which
is unique to this particular type of a controller and can be reliably
matched against.

@austinp-valve absolute path to the script is currently hardcoded to `/usr/local/bin` which may or may not be what we want. But more importantly, this repo doesn't have any provision to install said script, so I am hoping this is something you can either advise me on or handle on your end.