### PR TITLE
Add support for Faceoff Wired Pro Controller

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -37,6 +37,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660
 # Nintendo Switch Pro Controller over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0660", TAG+="uaccess"
 
+# Faceoff Wired Pro Controller for Nintendo Switch
+KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0180", MODE="0660", TAG+="uaccess"
+
 # PowerA Wired Controller for Nintendo Switch
 KERNEL=="hidraw*", ATTRS{idVendor}=="20d6", ATTRS{idProduct}=="a711", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Add support for Faceoff Wired Pro Controller for Nintendo Switch.
It is an off-brand Nintendo switch pro controller, and Steam does not currently detect it.