### PR TITLE
Update 60-steam-input.rules to include Horipad Mini

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -86,6 +86,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="0066", MODE="0660
 # HORIPAD for Nintendo Switch
 KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="00c1", MODE="0660", TAG+="uaccess"
 
+# HORIPAD mini 4
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="00ee", MODE="0660", TAG+="uaccess"
+
 # Armor Armor 3 Pad PS4
 KERNEL=="hidraw*", ATTRS{idVendor}=="0c12", ATTRS{idProduct}=="0e10", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Add support for Horipad mini 4*

*Button mapping is still not completely correct by default, but the controller is recognized, and can be remapped in Big Picture Mode