### PR TITLE
add Brooks Universal Fighting Board

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -74,6 +74,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="0738", ATTRS{idProduct}=="8250", MODE="0660
 # Mad Catz - Street Fighter V Arcade FightStick TE S+
 KERNEL=="hidraw*", ATTRS{idVendor}=="0738", ATTRS{idProduct}=="8384", MODE="0660", TAG+="uaccess"
 
+# Brooks Universal Fighting Board
+KERNEL=="hidraw*", ATTRS{idVendor}=="0c12", ATTRS{idProduct}=="0c30", MODE="0660", TAG+="uaccess"
+
 # EMiO Elite Controller for PS4
 KERNEL=="hidraw*", ATTRS{idVendor}=="0c12", ATTRS{idProduct}=="1cf6", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Brooks Universal Fighting Board is commonly used in custom built arcade hardware and fightsticks.