### PR TITLE
Add Razer Panthera EVO Arcade Stick

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -65,6 +65,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="1000", MODE="0660
 # Razer Raiju 2 Tournament Edition
 KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="1007", MODE="0660", TAG+="uaccess"
 
+# Razer Panthera EVO Arcade Stick
+KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="1008", MODE="0660", TAG+="uaccess"
+
 # Razer Panthera Arcade Stick
 KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0401", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
With help from this [comment on Reddit](https://www.reddit.com/r/linux_gaming/comments/lsn7x6/is_a_razer_panthera_evo_supported/gtxz96x/)

Tested by editing my Steam udev rules locally, I can confirm it enables the controller in Steam.