### PR TITLE
Add Razer Raiju Ultimate

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -72,6 +72,12 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="1008", MODE="0660
 # Razer Raiju PS4 Controller Tournament Edition over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*1532:100A*", MODE="0660", TAG+="uaccess"
 
+# Razer Raiju Ultimate over USB
+KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="1004", MODE="0660", TAG+="uaccess"
+
+# Razer Raiju Ultimate over PC Bluetooth
+KERNEL=="hidraw*", KERNELS=="*1532:1009*", MODE="0660", TAG+="uaccess"
+
 # Razer Panthera Arcade Stick
 KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0401", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Required to use the Razer Raiju Ultimate (firmware v1.05) with Steam on both USB and PC BT modes respectively. Tested with Steam Big Picture and Monster Train. No problems were found with Monster Train, but in Big Picture the trackpad seemed to constantly lose focus.

Steps to reproduce:
- Open Big Picture
- Open web->google
- Touch the right side of the trackpad, works normally
- Press right on the d-pad
- Touch the right side of the trackpad, no longer works