### PR TITLE
Add popular Thrustmaster HOTAS

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -125,3 +125,12 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 
 # Thrustmaster eSwap Pro
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
+
+# Thrustmaster TFRP Rudder
+KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b679", MODE="0660", TAG+="uaccess"
+
+# Thrustmaster TWCS Throttle
+KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b687", MODE="0660", TAG+="uaccess"
+
+# Thrustmaster T.16000M Joystick
+KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b10a", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
For Proton so it will expose correct mapping of axes for games.

The Proton bit to prefer hidraw has already landed in experimental:
https://github.com/ValveSoftware/wine/commit/1554f4c427433c377d96cf6ba3a484b6390c39df