### PR TITLE
Update 60-steam-input.rules

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -125,3 +125,6 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 
 # Thrustmaster eSwap Pro
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
+
+# PDP Rock Candy Wired Controller for Switch
+KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0187", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Adds the rockcandy pdp switch wired controller to udev.
Tested locally on my machine works in big picture mode.
If I did this right for my first pull request should just work as is.

Thanks in advance you people ROCK!