### PR TITLE
Add PDP Faceoff Deluxe+ Audio controller

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -37,8 +37,11 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660
 # Nintendo Switch Pro Controller over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*057E:2009*", MODE="0660", TAG+="uaccess"
 
-# Faceoff Wired Pro Controller for Nintendo Switch
+# PDP Faceoff Wired Pro Controller for Nintendo Switch
 KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0180", MODE="0660", TAG+="uaccess"
+
+# PDP Faceoff Deluxe+ Audio Wired Pro Controller for Nintendo Switch
+KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0184", MODE="0660", TAG+="uaccess"
 
 # PDP Wired Fight Pad Pro for Nintendo Switch
 KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0185", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
This controller (0e6f:0184) is similar to the "non-deluxe" PDP Wired controller for Switch which is already listed (0e6f:180). I tested this change and as far as I can tell, the controller works as expected in Steam.

Note that 0184 also includes a USB audio interface, connected to a 3.5mm jack on the controller. This audio interface "works for me" in Windows, but in Linux (Ubuntu 22.04), I can see the audio interface listed in my Sound control panel but I have not been able to make audio come out of it. Also, this audio interface seems to only expose itself to the host when a headset is physically connected to the jack - with nothing connected, neither Windows nor Linux seems to recognize the controller as an audio interface. I don't think solving this mystery is required to add support for the device as a gamepad.

There are some other minor differences between the two controllers, but all of that functionality seems to be handled "inside the hardware" so it is transparent to the host. For reference, 0180 includes "turbo" features, while 0184 has remappable back paddles that can be configured to act as any of the "regular" buttons on the controller.

I have both controllers in my possession so if anyone has more questions about them, I am happy to experiment and provide direct information.