### PR TITLE
Add DualShock 3 controller

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -10,6 +10,12 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
 # Valve HID devices over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*28DE:*", MODE="0660", TAG+="uaccess"
 
+# DualShock 3 over USB hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", MODE="0660", TAG+="uaccess"
+
+# DualShock 3 over bluetooth hidraw
+KERNEL=="hidraw*", KERNELS=="*054C:0268*", MODE="0660", TAG+="uaccess"
+
 # DualShock 4 over USB hidraw
 KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="05c4", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
The DualShock 3 controller is fully supported by Steam on Linux, including correct button prompts on the UI and a photo of the controller on Steam Input's controller configuration screen.