### PR TITLE
Support for Index bluetooth radios' serial port

### DIFF
--- a/60-steam-vr.rules
+++ b/60-steam-vr.rules
@@ -23,3 +23,5 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2150", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2300", MODE="0660", TAG+="uaccess"
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2301", MODE="0660", TAG+="uaccess"
+
+SUBSYSTEM=="tty", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2102", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Set the /dev/ttyACMx permissions for any tty with USB parent attributes of 28de + 2102 -> 0666 so anyone can write to it.

Otherwise, only those in uucp or dialout on some distros can write to it.