### PR TITLE
Added udev rule for Microsoft X-Box One S pad

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -137,3 +137,6 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 
 # Thrustmaster eSwap Pro
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
+
+# Microsoft X-Box One S pad
+SUBSYSTEM=="input", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02ea", MODE="0664", TAG+="uaccess" 


### PR DESCRIPTION
The only caveat is the use of MODE="0664".
It was the only way I could think of in order to be able to use the controller. 
When I plug it in, I get two files:  `/dev/input/js0` and `/dev/input/event23`.
Without this udev rule, I did not have read privileges on `/dev/input/event23`. As soon as I made it readable manually, steam managed to recognize it (so did Xorg) and I was able to use it normally.

OS: Gentoo GNU/Linux

