### PR TITLE
adds support for the "Victrix Pro FS-12 Arcade Fight Stick" in PS4/PS5 mode

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -137,3 +137,6 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 
 # Thrustmaster eSwap Pro
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
+
+# Performance Designed Products Victrix Pro FS-12 for PS4 & PS5
+KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="020c", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
This is for the purple version: https://pdp.com/products/victrix-pro-fs-12-arcade-fight-stick-purple

I _assume_ the white one has the same "idProduct".