### PR TITLE
Update 60-steam-input.rules to include rules for DualSense Edge

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -37,6 +37,12 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ce6", MODE="0660
 # PS5 DualSense controller over bluetooth hidraw
 KERNEL=="hidraw*", KERNELS=="*054C:0CE6*", MODE="0660", TAG+="uaccess"
 
+# Sony DualSense Edge Wireless-Controller over bluetooth hidraw
+KERNEL=="hidraw*", KERNELS=="*054C:0DF2*", MODE="0660", TAG+="uaccess"
+
+# Sony DualSense Edge Wireless-Controller over USB hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0df2", MODE="0660", TAG+="uaccess"
+
 # Nintendo Switch Pro Controller over USB hidraw
 KERNEL=="hidraw*", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2009", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
This should make the DualSense Edge fully functional. These rules have been taken from the Steam Deck's files and reformatted to better fit the rest of the rules in this file.

File From the Steam Deck: 71-sony-controllers.rules
If implemented, the DualSense Edge should function exactly as it does on the Steam Deck.