### PR TITLE
Add support for wired & wireless HORI ONYX PLUS Gamepad

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -137,3 +137,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 
 # Thrustmaster eSwap Pro
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
+
+# Hori Co., Ltd HORI Wireless Pad ONYX PLUS Wired
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="013f", MODE="0660", TAG+="uaccess"
+
+# Hori Co., Ltd HORI Wireless Pad ONYX PLUS Wireless
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="012b", MODE="0660", TAG+="uaccess"

--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -139,7 +139,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
 
 # Hori Co., Ltd HORI Wireless Pad ONYX PLUS Wired
-KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="013f", MODE="0660", TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="012d", MODE="0660", TAG+="uaccess"
 
 # Hori Co., Ltd HORI Wireless Pad ONYX PLUS Wireless
 KERNEL=="hidraw*", ATTRS{idVendor}=="0f0d", ATTRS{idProduct}=="012b", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Adds support for both modes of the [HORI ONYX PLUS.](https://hori.co.uk/onyx-plus-wireless-controller-for-playstation-4/)

Results of connecting the devices after `{all-for-now}` in each mode during `~/.steam/root/ubuntu12_32/steam-runtime/run.sh steam-runtime-input-monitor` are as follows:

<details>
<summary>Wired</summary>

```
{
  "added" : {
    "interface_flags" : [
      "event",
      "readable",
      "read-write"
    ],
    "type_flags" : [
      "joystick"
    ],
    "dev_node" : "/dev/input/event26",
    "subsystem" : "input",
    "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3/1-1.3:1.0/input/input43/event26",
    "bus_type" : "0x0003",
    "vendor_id" : "0x0f0d",
    "product_id" : "0x012d",
    "version" : "0x0101",
    "evdev" : {
      "types" : [
        "SYN",
        "KEY",
        "ABS",
        "FF"
      ],
      "absolute_axes" : [
        "X",
        "Y",
        "Z",
        "RX",
        "RY",
        "RZ",
        "HAT0X",
        "HAT0Y"
      ],
      "relative_axes" : [
      ],
      "keys" : [
        "BTN_A",
        "BTN_B",
        "BTN_X",
        "BTN_Y",
        "BTN_TL",
        "BTN_TR",
        "BTN_SELECT",
        "BTN_START",
        "BTN_MODE",
        "BTN_THUMBL",
        "BTN_THUMBR"
      ],
      "input_properties" : [
      ]
    },
    "udev_properties" : [
      ".INPUT_CLASS=joystick",
      "ACTION=add",
      "CURRENT_TAGS=:uaccess:seat:",
      "DEVLINKS=/dev/input/by-id/usb-HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000-event-joystick /dev/input/by-path/pci-0000:00:14.0-usb-0:1.3:1.0-event-joystick /dev/input/by-path/pci-0000:00:14.0-usbv2-0:1.3:1.0-event-joystick",
      "DEVNAME=/dev/input/event26",
      "DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3/1-1.3:1.0/input/input43/event26",
      "ID_BUS=usb",
      "ID_FOR_SEAT=input-pci-0000_00_14_0-usb-0_1_3_1_0",
      "ID_INPUT=1",
      "ID_INPUT_JOYSTICK=1",
      "ID_MODEL=HORI_Wireless_Pad_ONYX_PLUS",
      "ID_MODEL_ENC=HORI\\x20Wireless\\x20Pad\\x20ONYX\\x20PLUS",
      "ID_MODEL_ID=012d",
      "ID_PATH=pci-0000:00:14.0-usb-0:1.3:1.0",
      "ID_PATH_TAG=pci-0000_00_14_0-usb-0_1_3_1_0",
      "ID_PATH_WITH_USB_REVISION=pci-0000:00:14.0-usbv2-0:1.3:1.0",
      "ID_REVISION=0101",
      "ID_SERIAL=HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000",
      "ID_SERIAL_SHORT=12340000",
      "ID_TYPE=generic",
      "ID_USB_DRIVER=xpad",
      "ID_USB_INTERFACES=:ff5d01:",
      "ID_USB_INTERFACE_NUM=00",
      "ID_USB_MODEL=HORI_Wireless_Pad_ONYX_PLUS",
      "ID_USB_MODEL_ENC=HORI\\x20Wireless\\x20Pad\\x20ONYX\\x20PLUS",
      "ID_USB_MODEL_ID=012d",
      "ID_USB_REVISION=0101",
      "ID_USB_SERIAL=HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000",
      "ID_USB_SERIAL_SHORT=12340000",
      "ID_USB_TYPE=generic",
      "ID_USB_VENDOR=HORI_CO._LTD.",
      "ID_USB_VENDOR_ENC=HORI\\x20CO.\\x2cLTD.",
      "ID_USB_VENDOR_ID=0f0d",
      "ID_VENDOR=HORI_CO._LTD.",
      "ID_VENDOR_ENC=HORI\\x20CO.\\x2cLTD.",
      "ID_VENDOR_ID=0f0d",
      "LIBINPUT_DEVICE_GROUP=3/f0d/12d:usb-0000:00:14.0-1",
      "MAJOR=13",
      "MINOR=90",
      "SEQNUM=5395",
      "SUBSYSTEM=input",
      "TAGS=:uaccess:seat:",
      "USEC_INITIALIZED=941857441"
    ],
    "input_ancestor" : {
      "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3/1-1.3:1.0/input/input43",
      "name" : "Generic X-Box pad",
      "bus_type" : "0x0003",
      "vendor_id" : "0x0f0d",
      "product_id" : "0x012d",
      "version" : "0x0101"
    },
    "usb_device_ancestor" : {
      "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3",
      "vendor_id" : "0x0f0d",
      "product_id" : "0x012d",
      "version" : "0x0101",
      "manufacturer" : "HORI CO.,LTD.",
      "product" : "HORI Wireless Pad ONYX PLUS",
      "serial" : "12340000"
    }
  }
}
{
  "added" : {
    "interface_flags" : [
      "event",
      "readable",
      "read-write"
    ],
    "type_flags" : [
      "joystick"
    ],
    "dev_node" : "/dev/input/event27",
    "subsystem" : "input",
    "sys_path" : "/sys/devices/virtual/input/input44/event27",
    "bus_type" : "0x0003",
    "vendor_id" : "0x28de",
    "product_id" : "0x11ff",
    "version" : "0x0001",
    "evdev" : {
      "types" : [
        "SYN",
        "KEY",
        "ABS",
        "FF"
      ],
      "absolute_axes" : [
        "X",
        "Y",
        "Z",
        "RX",
        "RY",
        "RZ",
        "HAT0X",
        "HAT0Y"
      ],
      "relative_axes" : [
      ],
      "keys" : [
        "BTN_A",
        "BTN_B",
        "BTN_X",
        "BTN_Y",
        "BTN_TL",
        "BTN_TR",
        "BTN_SELECT",
        "BTN_START",
        "BTN_MODE",
        "BTN_THUMBL",
        "BTN_THUMBR"
      ],
      "input_properties" : [
      ]
    },
    "udev_properties" : [
      ".INPUT_CLASS=joystick",
      "ACTION=add",
      "CURRENT_TAGS=:uaccess:seat:",
      "DEVNAME=/dev/input/event27",
      "DEVPATH=/devices/virtual/input/input44/event27",
      "ID_INPUT=1",
      "ID_INPUT_JOYSTICK=1",
      "ID_SERIAL=noserial",
      "MAJOR=13",
      "MINOR=91",
      "SEQNUM=5400",
      "SUBSYSTEM=input",
      "TAGS=:uaccess:seat:",
      "USEC_INITIALIZED=943084927"
    ],
    "input_ancestor" : {
      "sys_path" : "/sys/devices/virtual/input/input44",
      "name" : "Microsoft X-Box 360 pad 0",
      "bus_type" : "0x0003",
      "vendor_id" : "0x28de",
      "product_id" : "0x11ff",
      "version" : "0x0001"
    }
  }
}
```
</details>

<details>
<summary>Wireless</summary>

```
{
  "added" : {
    "interface_flags" : [
      "event",
      "readable",
      "read-write"
    ],
    "type_flags" : [
      "joystick"
    ],
    "dev_node" : "/dev/input/event23",
    "subsystem" : "input",
    "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-7/1-7:1.0/input/input38/event23",
    "bus_type" : "0x0003",
    "vendor_id" : "0x0f0d",
    "product_id" : "0x012b",
    "version" : "0x0101",
    "evdev" : {
      "types" : [
        "SYN",
        "KEY",
        "ABS",
        "FF"
      ],
      "absolute_axes" : [
        "X",
        "Y",
        "Z",
        "RX",
        "RY",
        "RZ",
        "HAT0X",
        "HAT0Y"
      ],
      "relative_axes" : [
      ],
      "keys" : [
        "BTN_A",
        "BTN_B",
        "BTN_X",
        "BTN_Y",
        "BTN_TL",
        "BTN_TR",
        "BTN_SELECT",
        "BTN_START",
        "BTN_MODE",
        "BTN_THUMBL",
        "BTN_THUMBR"
      ],
      "input_properties" : [
      ]
    },
    "udev_properties" : [
      ".INPUT_CLASS=joystick",
      "ACTION=add",
      "CURRENT_TAGS=:seat:uaccess:",
      "DEVLINKS=/dev/input/by-id/usb-HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000-event-joystick /dev/input/by-path/pci-0000:00:14.0-usb-0:7:1.0-event-joystick /dev/input/by-path/pci-0000:00:14.0-usbv2-0:7:1.0-event-joystick",
      "DEVNAME=/dev/input/event23",
      "DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-7/1-7:1.0/input/input38/event23",
      "ID_BUS=usb",
      "ID_FOR_SEAT=input-pci-0000_00_14_0-usb-0_7_1_0",
      "ID_INPUT=1",
      "ID_INPUT_JOYSTICK=1",
      "ID_MODEL=HORI_Wireless_Pad_ONYX_PLUS",
      "ID_MODEL_ENC=HORI\\x20Wireless\\x20Pad\\x20ONYX\\x20PLUS",
      "ID_MODEL_ID=012b",
      "ID_PATH=pci-0000:00:14.0-usb-0:7:1.0",
      "ID_PATH_TAG=pci-0000_00_14_0-usb-0_7_1_0",
      "ID_PATH_WITH_USB_REVISION=pci-0000:00:14.0-usbv2-0:7:1.0",
      "ID_REVISION=0101",
      "ID_SERIAL=HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000",
      "ID_SERIAL_SHORT=12340000",
      "ID_TYPE=generic",
      "ID_USB_DRIVER=xpad",
      "ID_USB_INTERFACES=:ff5d01:",
      "ID_USB_INTERFACE_NUM=00",
      "ID_USB_MODEL=HORI_Wireless_Pad_ONYX_PLUS",
      "ID_USB_MODEL_ENC=HORI\\x20Wireless\\x20Pad\\x20ONYX\\x20PLUS",
      "ID_USB_MODEL_ID=012b",
      "ID_USB_REVISION=0101",
      "ID_USB_SERIAL=HORI_CO._LTD._HORI_Wireless_Pad_ONYX_PLUS_12340000",
      "ID_USB_SERIAL_SHORT=12340000",
      "ID_USB_TYPE=generic",
      "ID_USB_VENDOR=HORI_CO._LTD.",
      "ID_USB_VENDOR_ENC=HORI\\x20CO.\\x2cLTD.",
      "ID_USB_VENDOR_ID=0f0d",
      "ID_VENDOR=HORI_CO._LTD.",
      "ID_VENDOR_ENC=HORI\\x20CO.\\x2cLTD.",
      "ID_VENDOR_ID=0f0d",
      "LIBINPUT_DEVICE_GROUP=3/f0d/12b:usb-0000:00:14.0-7",
      "MAJOR=13",
      "MINOR=87",
      "SEQNUM=5337",
      "SUBSYSTEM=input",
      "TAGS=:seat:uaccess:",
      "USEC_INITIALIZED=477349501"
    ],
    "input_ancestor" : {
      "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-7/1-7:1.0/input/input38",
      "name" : "Generic X-Box pad",
      "bus_type" : "0x0003",
      "vendor_id" : "0x0f0d",
      "product_id" : "0x012b",
      "version" : "0x0101"
    },
    "usb_device_ancestor" : {
      "sys_path" : "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-7",
      "vendor_id" : "0x0f0d",
      "product_id" : "0x012b",
      "version" : "0x0101",
      "manufacturer" : "HORI CO.,LTD.",
      "product" : "HORI Wireless Pad ONYX PLUS",
      "serial" : "12340000"
    }
  }
}
{
  "added" : {
    "interface_flags" : [
      "event",
      "readable",
      "read-write"
    ],
    "type_flags" : [
      "joystick"
    ],
    "dev_node" : "/dev/input/event24",
    "subsystem" : "input",
    "sys_path" : "/sys/devices/virtual/input/input39/event24",
    "bus_type" : "0x0003",
    "vendor_id" : "0x28de",
    "product_id" : "0x11ff",
    "version" : "0x0001",
    "evdev" : {
      "types" : [
        "SYN",
        "KEY",
        "ABS",
        "FF"
      ],
      "absolute_axes" : [
        "X",
        "Y",
        "Z",
        "RX",
        "RY",
        "RZ",
        "HAT0X",
        "HAT0Y"
      ],
      "relative_axes" : [
      ],
      "keys" : [
        "BTN_A",
        "BTN_B",
        "BTN_X",
        "BTN_Y",
        "BTN_TL",
        "BTN_TR",
        "BTN_SELECT",
        "BTN_START",
        "BTN_MODE",
        "BTN_THUMBL",
        "BTN_THUMBR"
      ],
      "input_properties" : [
      ]
    },
    "udev_properties" : [
      ".INPUT_CLASS=joystick",
      "ACTION=add",
      "CURRENT_TAGS=:seat:uaccess:",
      "DEVNAME=/dev/input/event24",
      "DEVPATH=/devices/virtual/input/input39/event24",
      "ID_INPUT=1",
      "ID_INPUT_JOYSTICK=1",
      "ID_SERIAL=noserial",
      "MAJOR=13",
      "MINOR=88",
      "SEQNUM=5342",
      "SUBSYSTEM=input",
      "TAGS=:seat:uaccess:",
      "USEC_INITIALIZED=478690724"
    ],
    "input_ancestor" : {
      "sys_path" : "/sys/devices/virtual/input/input39",
      "name" : "Microsoft X-Box 360 pad 0",
      "bus_type" : "0x0003",
      "vendor_id" : "0x28de",
      "product_id" : "0x11ff",
      "version" : "0x0001"
    }
  }
}

```
</details>