### PR TITLE
Add Razer Wolverine V2 Pro (Wired/PS5 mode)

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -87,6 +87,9 @@ KERNEL=="hidraw*", KERNELS=="*1532:1009*", MODE="0660", TAG+="uaccess"
 # Razer Panthera Arcade Stick
 KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0401", MODE="0660", TAG+="uaccess"
 
+# Razer Wolverine V2 Pro in wired PS5 mode
+KERNEL=="hidraw*", ATTRS{idVendor}=="1532", ATTRS{idProduct}=="100b", MODE="0660", TAG+="uaccess"
+
 # Mad Catz - Street Fighter V Arcade FightPad PRO
 KERNEL=="hidraw*", ATTRS{idVendor}=="0738", ATTRS{idProduct}=="8250", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Inputs still need to be setup when the controller is first used with Steam. I've submitted https://github.com/gabomdq/SDL_GameControllerDB/pull/696 which should fix that.