### PR TITLE
Added rules for Wii U, Switch, Switch 2 GameCube controllers

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -213,3 +213,9 @@ KERNEL=="hidraw*", KERNELS=="*2DC8:*", MODE="0660", TAG+="uaccess"
 
 # Flydigi 2.4 GHz / Wired
 KERNEL=="hidraw*", ATTRS{idVendor}=="04b4", MODE="0660", TAG+="uaccess"
+
+# Nintendo Wii U/Switch Wired GameCube Controller Adapter
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0660", TAG+="uaccess"
+
+# Nintendo Switch 2 GameCube Controller over USB
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="2073", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
This matches the hardware support added in the most recent Steam Client Beta update (currently Windows-only but should be using the hidapi drivers from SDL).