### PR TITLE
Add Bigscreen Beyond for SteamVR

### DIFF
--- a/60-steam-vr.rules
+++ b/60-steam-vr.rules
@@ -25,3 +25,13 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct
 KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2301", MODE="0660", TAG+="uaccess"
 
 SUBSYSTEM=="tty", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="2102", MODE="0660", TAG+="uaccess"
+
+# Bigscreen Beyond
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="35bd", ATTRS{idProduct}=="0101", MODE="0660", TAG+="uaccess"
+# Bigscreen Bigeye
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="35bd", ATTRS{idProduct}=="0202", MODE="0660", TAG+="uaccess"
+# Bigscreen Beyond Audio Strap
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="35bd", ATTRS{idProduct}=="0105", MODE="0660", TAG+="uaccess"
+# Bigscreen Beyond Firmware Mode?
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="35bd", ATTRS{idProduct}=="4004", MODE="0660", TAG+="uaccess"
+


### PR DESCRIPTION
I understand that this might not get accepted but these are devices that work with SteamVR and need udev rules to work.

The reason I'm making this is that `60-steam-input.rules` contains devices that Valve doesn't produce/make but does allow Steam users to use those devices as they'd expect to. So the intention is that VR headsets can be easily supported for SteamVR in downstream distros.