### PR TITLE
Fix EdgeTX and OpenTX RC rule

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -167,7 +167,7 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="9886", ATTRS{idProduct}=="0025", MODE="0660
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="d00e", MODE="0660", TAG+="uaccess"
 
 # EdgeTX and OpenTX radio controllers in gamepad mode over USB hidraw
-KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4f54", MODE="0660" TAG+="uaccess"
+KERNEL=="hidraw*", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="4f54", MODE="0660", TAG+="uaccess"
 
 # Thrustmaster TFRP Rudder
 KERNEL=="hidraw*", ATTRS{idVendor}=="044f", ATTRS{idProduct}=="b679", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
While troubleshooting USB issues on my own machine, I ran `udevadm verify` and saw a rule failure in this file because of a missing comma. I figured I'd send a patch, given how easy the fix is.