### PR TITLE
Update 60-steam-input.rules

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -229,6 +229,9 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="04b4", MODE="0660", TAG+="uaccess"
 # Flydigi HIDAPI Enhanced Mode
 KERNEL=="hidraw*", ATTRS{idVendor}=="37d7", MODE="0660", TAG+="uaccess"
 
+# VIRPIL Controls HID devices over USB hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="3344", MODE="0660", TAG+="uaccess"
+
 # Nintendo Wii U/Switch Wired GameCube Controller Adapter
 SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="057e", ATTRS{idProduct}=="0337", MODE="0660", TAG+="uaccess"
 


### PR DESCRIPTION
Add hidraw uaccess rule for VIRPIL Controls devices (VID 0x3344). Covers all current and future VIRPIL products using a vendor-wide rule, consistent with the existing 8bitdo and Flydigi entries.