### PR TITLE
steam-input.rules: Only enable wakeup if the attribute exists

### DIFF
--- a/60-steam-input.rules
+++ b/60-steam-input.rules
@@ -14,7 +14,7 @@ SUBSYSTEM=="hidraw", ATTRS{id/vendor}=="28de", MODE="0660", TAG+="uaccess"
 SUBSYSTEM=="input", ATTRS{id/vendor}=="28de", MODE="0660", TAG+="uaccess"
 
 # Allow wakeup from Valve devices (Steam Controller 2015 receiver, Steam Controller 2026 receiver, Steam Machine Bluetooth) 
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTR{power/wakeup}="enabled"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", ATTR{power/wakeup}=="*", ATTR{power/wakeup}="enabled"
 
 # DualShock 3 over USB hidraw
 KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0268", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Not all USB device nodes have this attribute, so only enable it if it's there to be enabled. This avoids errors in the system log, like:

`(udev-worker)[6167]: 1-9:1.0:
/usr/lib/udev/rules.d/60-steam-input.rules:17 Failed to write ATTR{/sys/devices/pci0000:00/0000:00:14.0/usb1/1-9/1-9:1.0/power/wakeup}, ignoring: No such file or directory`

(in this case when plugging in a Steam Controller (2015) USB dongle)

steamrt/tasks#948